### PR TITLE
[GAP-1886] Print none-thrown exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,10 @@ module.exports.handler = RavenLambdaWrapper.handler(ravenConfig, (event, context
 
 ## Version History
 
+### 1.1.3
+log to console errors that are not thrown out
+
+
 ### 1.1.2
 
 * Added plugin debug messages and flag

--- a/src/index.js
+++ b/src/index.js
@@ -264,6 +264,10 @@ function wrapCallback(pluginConfig, cb) {
 				debug("exception and sentry capture turned off", err.message);
 				cb(throwOut, data);
 			}
+			if (!throwOut) {
+				// we want to trace the exception if we don't throw it out. 
+				console.log("Exception occured, Sentry.throwOut: false", err);
+			}
 		}
 		else {
 			cb(throwOut, data);
@@ -309,6 +313,7 @@ class RavenLambdaWrapper {
 	 * @param {boolean} [pluginConfig.captureTimeoutErrors] - monitor execution timeouts errors (defaults to `true`)
  	 * @param {boolean} [pluginConfig.printEventToStdout] - print the event with console log (defaults to `false`)
 	 * @param {boolean} [pluginConfig.filterEventsFields] - filter out list of fields from the event data (defaults to ''.Example for not empty:'body,headers')
+	 * @param {Array} [pluginConfig.fingerPrint] - throw out the error after capturing it. (defaults to `[{{defualt}}]`)
 	 * @param {boolean} [pluginConfig.throwOut] - throw out the error after capturing it. (defaults to `true`)
 	 * @param {Function} handler - Original Lambda function handler
 	 * @return {Function} - Wrapped Lambda function handler with Sentry instrumentation
@@ -477,7 +482,13 @@ class RavenLambdaWrapper {
 									});
 								}
 								else {
-									return pluginConfig.throwOut ? Promise.reject(err) : Promise.resolve(true);
+									if (pluginConfig.throwOut) {
+										Promise.reject(err);
+									} else {
+										// we want to trace the exception if we don't throw it out. 
+										console.log("Exception occured, Sentry.throwOut: false", err);
+										Promise.resolve(true);
+									}
 								}
 							});
 					}

--- a/src/index.js
+++ b/src/index.js
@@ -313,7 +313,6 @@ class RavenLambdaWrapper {
 	 * @param {boolean} [pluginConfig.captureTimeoutErrors] - monitor execution timeouts errors (defaults to `true`)
  	 * @param {boolean} [pluginConfig.printEventToStdout] - print the event with console log (defaults to `false`)
 	 * @param {boolean} [pluginConfig.filterEventsFields] - filter out list of fields from the event data (defaults to ''.Example for not empty:'body,headers')
-	 * @param {Array} [pluginConfig.fingerPrint] - throw out the error after capturing it. (defaults to `[{{defualt}}]`)
 	 * @param {boolean} [pluginConfig.throwOut] - throw out the error after capturing it. (defaults to `true`)
 	 * @param {Function} handler - Original Lambda function handler
 	 * @return {Function} - Wrapped Lambda function handler with Sentry instrumentation


### PR DESCRIPTION
When sentry capture errors flag is off, and throwOut is false, print error to stdout.
https://puresec-team.atlassian.net/browse/GAP-1886
